### PR TITLE
Analyze Result Page & Navigation Bar minor changes

### DIFF
--- a/AIHOPS/Front/src/Components/EditPopup.jsx
+++ b/AIHOPS/Front/src/Components/EditPopup.jsx
@@ -501,7 +501,7 @@ const EditPopup = ({ fetchProjects, fetch_selected_project, setIsSuccess, setMsg
                             className="action-btn edit-btn"
                             onClick={() => {setAnalyzePopupType('showSeverityFactorsScore')}}
                         >
-                            Show d-Score (Severity Factors)
+                            Show d-Score
                         </button>
                         <AnalyzeResult analyzePopupType = {analyzePopupType} closePopup = {closePopup} projectId={selectedProject.id} />
                     </div>

--- a/AIHOPS/Front/src/Components/NavBar.jsx
+++ b/AIHOPS/Front/src/Components/NavBar.jsx
@@ -33,11 +33,11 @@ const NavBar = () => {
                 </li>
 
                 {/* _old Projects Management button */}
-                <li className="nav-item">
+                {/* <li className="nav-item">
                   <Link to="/projectsmanagement_old" className="nav-link nav-button">
                     Projects Management _old
                   </Link>
-                </li>
+                </li> */}
 
                 {/* MyProjects button */}
                 <li className="nav-item">


### PR DESCRIPTION
1. Removed the old projects management page from the navigation bar.
2. Changed the last button in analyze result to be 'Show d-Score' - without the '(severity factors)' reference after it