### PR TITLE
Verify tab in nav-bar and gmailor message

### DIFF
--- a/AIHOPS/Domain/src/Users/Gmailor.py
+++ b/AIHOPS/Domain/src/Users/Gmailor.py
@@ -26,7 +26,7 @@ class Gmailor:
 
                     yag = yagmail.SMTP("testsemailaihops@gmail.com", "vljh sdgy syee jizw")
                     yag.send(email, "AIHOPS verification email",
-                             f"Hello from AIHOPS!\nverification code: < {code} >\nOr click here: http://localhost:5173/verifyautomatic?token={code}")
+                             f"Hello from AIHOPS!\nPlease click here to verify your account: http://localhost:5173/verifyautomatic?token={code}\nOnce you've verified it, you can login to your account.\n\nBest regards,\nAIHOPS Team")
 
                     return ResponseSuccessMsg(
                         f"an email with verification code has been sent to {email}, you have 5 minutes to validate your account")

--- a/AIHOPS/Front/src/App.jsx
+++ b/AIHOPS/Front/src/App.jsx
@@ -45,7 +45,7 @@ const AppContent = () => {
       <Routes>
         <Route path="/" element={<WelcomePage />} />
         <Route path="/register" element={<Register />} />
-        <Route path="/verify" element={<Verify />} />
+        {/* <Route path="/verify" element={<Verify />} /> */}
         <Route path="/verifyautomatic" element={<VerifyAutomatic />} />
         <Route path="/login" element={<Login />} />
         <Route path="/notification" element={<Notification />} />

--- a/AIHOPS/Front/src/Components/NavBar.jsx
+++ b/AIHOPS/Front/src/Components/NavBar.jsx
@@ -133,7 +133,7 @@ const NavBar = () => {
                       Register
                     </Link>
                   </li>
-                  <li className="nav-item">
+                  {/* <li className="nav-item">
                     <Link
                         to="/verify"
                         className={`nav-link nav-button ${
@@ -142,7 +142,7 @@ const NavBar = () => {
                     >
                       Verify
                     </Link>
-                  </li>
+                  </li> */}
                 </>
             )}
           </ul>


### PR DESCRIPTION
Worked on two things: 
1. Remove the 'verify' tabs from the nav-bar.
2. Removing the code from the gmailor message.